### PR TITLE
Potential fix for code scanning alert no. 8: Cross-site scripting

### DIFF
--- a/src/main/java/com/nitramite/porssiohjain/contollers/SitemapController.java
+++ b/src/main/java/com/nitramite/porssiohjain/contollers/SitemapController.java
@@ -86,15 +86,17 @@ public class SitemapController {
     public ResponseEntity<String> sitemap(HttpServletRequest request) {
         String host = request.getHeader("host");
 
-        System.out.println(host);
-
         if (!DOMAIN_PAGES.containsKey(host)) {
-            return ResponseEntity.badRequest().body("Unknown domain: " + host);
+            return ResponseEntity.badRequest().body("Unknown domain: " + escapeXml(host));
         }
 
-        List<String> pages = DOMAIN_PAGES.get(host);
+        String canonicalHost = DOMAIN_PAGES.keySet().stream()
+                .filter(host::equals)
+                .findFirst()
+                .orElse(host);
+        List<String> pages = DOMAIN_PAGES.get(canonicalHost);
         String scheme = request.getScheme();
-        String domain = scheme + "://" + host;
+        String domain = scheme + "://" + canonicalHost;
 
         StringBuilder sb = new StringBuilder();
         sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
@@ -103,7 +105,7 @@ public class SitemapController {
         String today = LocalDate.now().toString();
         for (String path : pages) {
             sb.append("  <url>\n");
-            sb.append("    <loc>").append(domain).append(path).append("</loc>\n");
+            sb.append("    <loc>").append(escapeXml(domain)).append(escapeXml(path)).append("</loc>\n");
             sb.append("    <lastmod>").append(today).append("</lastmod>\n");
             sb.append("    <changefreq>weekly</changefreq>\n");
             sb.append("    <priority>0.5</priority>\n");
@@ -114,6 +116,18 @@ public class SitemapController {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_XML);
         return ResponseEntity.ok().headers(headers).body(sb.toString());
+    }
+
+    private static String escapeXml(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
     }
 
 }

--- a/src/main/java/com/nitramite/porssiohjain/contollers/SitemapController.java
+++ b/src/main/java/com/nitramite/porssiohjain/contollers/SitemapController.java
@@ -87,7 +87,7 @@ public class SitemapController {
         String host = request.getHeader("host");
 
         if (!DOMAIN_PAGES.containsKey(host)) {
-            return ResponseEntity.badRequest().body("Unknown domain: " + escapeXml(host));
+            return ResponseEntity.badRequest().body("Unknown domain");
         }
 
         String canonicalHost = DOMAIN_PAGES.keySet().stream()


### PR DESCRIPTION
Potential fix for [https://github.com/norkator/porssiohjain/security/code-scanning/8](https://github.com/norkator/porssiohjain/security/code-scanning/8)

To fix this properly, avoid reflecting raw `Host` header content into the XML at all. Since you already have an allowlist (`DOMAIN_PAGES`), use a **trusted canonical host value** from that allowlist for output generation, and escape XML text as defense-in-depth.

Best fix in this file:
1. Keep reading `host` for routing/selection.
2. After allowlist validation, resolve `canonicalHost` from the matching allowlist key and use that in `domain` instead of raw `host`.
3. XML-escape text inserted into `<loc>` (domain/path) and error body content.
4. Remove the debug `System.out.println(host);` to avoid logging untrusted header directly.

This preserves functionality (same allowed domains/pages) while removing direct user-controlled reflection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
