### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/norkator/porssiohjain/security/code-scanning/3](https://github.com/norkator/porssiohjain/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/test.yml` so the workflow does not inherit broader defaults.  
Best fix without changing functionality: define workflow-level minimal permission:

- `contents: read`

This is sufficient for the shown steps and aligns with CodeQL’s recommended minimum.  
Edit location: insert the block after the `on:` trigger section and before `jobs:`.

No imports, methods, or dependencies are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
