### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - production
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/norkator/porssiohjain:latest


### PR DESCRIPTION
Potential fix for [https://github.com/norkator/porssiohjain/security/code-scanning/1](https://github.com/norkator/porssiohjain/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (or job level). Best single fix here is at the root so all current/future jobs inherit safe defaults unless overridden.

For this workflow’s current behavior:
- `actions/checkout` needs `contents: read`.
- Pushing to GitHub Container Registry via `docker/login-action` + `docker/build-push-action` needs `packages: write`.

So update `.github/workflows/container.yml` by inserting:

```yml
permissions:
  contents: read
  packages: write
```

immediately after the `on:` trigger block (before `env:` is a clean location). No imports/dependencies/methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
