### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hybrid-web-container.yml
+++ b/.github/workflows/hybrid-web-container.yml
@@ -9,6 +9,10 @@ on:
       - ".github/workflows/hybrid-web-container.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/norkator/porssiohjain-hybrid-web:latest


### PR DESCRIPTION
Potential fix for [https://github.com/norkator/porssiohjain/security/code-scanning/2](https://github.com/norkator/porssiohjain/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` has only the scopes this workflow needs.

Best fix (without changing behavior): add workflow-level permissions below `on:` (or below `env:`) so all jobs inherit it. For this workflow, use:
- `contents: read` (required by checkout)
- `packages: write` (required to push image to GHCR)

Only `.github/workflows/hybrid-web-container.yml` needs editing. No imports/methods/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
