### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an error message

### DIFF
--- a/src/main/java/com/nitramite/porssiohjain/auth/AuthInterceptor.java
+++ b/src/main/java/com/nitramite/porssiohjain/auth/AuthInterceptor.java
@@ -59,7 +59,7 @@ public class AuthInterceptor implements HandlerInterceptor {
             authContext.setAccountId(account.getId());
         } catch (IllegalArgumentException e) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.getWriter().write(e.getMessage());
+            response.getWriter().write("Unauthorized");
             return false;
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/norkator/porssiohjain/security/code-scanning/5](https://github.com/norkator/porssiohjain/security/code-scanning/5)

Use a generic unauthorized response message instead of returning `e.getMessage()` to the client.

Best fix in this file:
- In `preHandle(...)`, replace the response body in the `catch (IllegalArgumentException e)` block with a constant generic message like `"Unauthorized"`.
- Do not expose exception details in the HTTP response.
- No behavior change to status code or control flow (`401`, `return false`)—only sanitizes output.

File/region to change:
- `src/main/java/com/nitramite/porssiohjain/auth/AuthInterceptor.java`
- Catch block around lines 60–63.

No new imports, methods, or dependencies are required for this minimal secure fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
