### PR TITLE
Potential fix for code scanning alert no. 10: Cross-site scripting

### DIFF
--- a/src/main/java/com/nitramite/porssiohjain/contollers/SitemapController.java
+++ b/src/main/java/com/nitramite/porssiohjain/contollers/SitemapController.java
@@ -84,16 +84,16 @@ public class SitemapController {
 
     @GetMapping(value = "/sitemap.xml", produces = MediaType.APPLICATION_XML_VALUE)
     public ResponseEntity<String> sitemap(HttpServletRequest request) {
-        String host = request.getHeader("host");
+        String hostHeader = request.getHeader("host");
 
-        if (!DOMAIN_PAGES.containsKey(host)) {
+        String canonicalHost = DOMAIN_PAGES.keySet().stream()
+                .filter(domainKey -> domainKey.equalsIgnoreCase(hostHeader))
+                .findFirst()
+                .orElse(null);
+        if (canonicalHost == null) {
             return ResponseEntity.badRequest().body("Unknown domain");
         }
 
-        String canonicalHost = DOMAIN_PAGES.keySet().stream()
-                .filter(host::equals)
-                .findFirst()
-                .orElse(host);
         List<String> pages = DOMAIN_PAGES.get(canonicalHost);
         String scheme = request.getScheme();
         String domain = scheme + "://" + canonicalHost;


### PR DESCRIPTION
Potential fix for [https://github.com/norkator/porssiohjain/security/code-scanning/10](https://github.com/norkator/porssiohjain/security/code-scanning/10)

General fix: do not use request-controlled `Host` header to construct output URLs. Instead, map request host to a canonical server-defined domain and use that canonical value for sitemap URL generation; still escape XML output.

Best fix in this file:
- In `sitemap(HttpServletRequest request)`, replace `host` handling with a canonical domain lookup that never falls back to tainted input.
- Remove `.orElse(host)` and replace with a null-safe lookup from trusted keys.
- Build `domain` from the canonical trusted key only.
- Keep existing `escapeXml` for XML encoding.

Specific region to change:
- `src/main/java/com/nitramite/porssiohjain/contollers/SitemapController.java`, around lines 87–100.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
